### PR TITLE
Fix GitHub Packages credentials in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,8 @@ dependencyResolutionManagement {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/Appversation/AppstentCompose")
             credentials {
-                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }


### PR DESCRIPTION
## Changes
- Fixed GitHub Packages credentials in settings.gradle to use environment variables directly
- Removed project.findProperty() calls that were causing build failures