### PR TITLE
Update repository order and bump version to 1.5.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,5 +63,5 @@ dependencies {
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
-    implementation 'com.appversation:appstent-compose:1.5.7'
+    implementation 'com.appversation:appstent-compose:1.5.8'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,5 @@
 pluginManagement {
     repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
-    }
-}
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
         maven {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/Appversation/AppstentCompose")
@@ -18,6 +8,24 @@ dependencyResolutionManagement {
                 password = System.getenv("GITHUB_TOKEN")
             }
         }
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/Appversation/AppstentCompose")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+        google()
+        mavenCentral()
     }
 }
 rootProject.name = "AppstentCompose"


### PR DESCRIPTION
## Changes
- Updated GitHub Packages repository order to be checked first
- Added GitHub Packages to pluginManagement repositories
- Bumped version to 1.5.8
- Updated app's dependency to use new version